### PR TITLE
Fix TimeHistogram x-labels for hourly and daily time windows

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/graphstatview/decorators/GraphStatTimeHistogramDecorator.kt
+++ b/app/src/main/java/com/samco/trackandgraph/graphstatview/decorators/GraphStatTimeHistogramDecorator.kt
@@ -131,10 +131,21 @@ class GraphStatTimeHistogramDecorator(listMode: Boolean) :
                     toAppendTo: StringBuffer,
                     pos: FieldPosition
                 ): StringBuffer {
-                    val index = (obj as Double).roundToInt() + 1
-                    val str = if (index > 0 && index <= data!!.window!!.numBins) {
+                    val zeroIndexOffset =
+                        // The bins we get start at index 0. The bin index can represent minutes, hours,
+                        // day of the week or day of the month, etc.
+                        // Since there is a hour 0 and a minute 0, but not a day or week 0 we have
+                        // to add an offset of 1 to the labels if talking about days or weeks.
+                        if (data!!.window!! == TimeHistogramWindow.DAY
+                            || data!!.window!! == TimeHistogramWindow.HOUR)
+                            0  // there is a minute 0 and a hour 0: index 0 -> label 0
+                        else 1 // but there is no day 0 or week 0:  index 0 -> label 1
+
+                    val index = (obj as Double).roundToInt() + zeroIndexOffset
+                    val str = if (index >= zeroIndexOffset
+                                    && index <= data!!.window!!.numBins) {
                         val labelInterval = getLabelInterval(data!!.window!!)
-                        if (index == 1
+                        if (index == zeroIndexOffset
                             || index == data!!.window!!.numBins
                             || index % labelInterval == 0
                         ) index.toString()


### PR DESCRIPTION
Hi,
this PR fixes the following bug: If you track something at 09:30 and plot the event using a TimeHistogram with the _daily_ time-window size, it will appear as if the event happened between 10:00-10:59 (one hour later).
This is due to the fact that there is an hour 0 in the day, but not a day 0 in the week nor a day 0 in the month (we start counting at 1 in those latter cases). Because of this there was a constant 1 added to all the labels (line 134 in the old code) when it should have only been added in specific cases.

The fix is pretty straight forward, however:

- I am not super happy with the variable name zeroIndexOffset, I would be open to change it.

- I don't have a lot of Kotlin experience, if there is a more kotlin way to do what I did I would be glad if you pointed it out.