### PR TITLE
Fix: Moving average window is one day longer 

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
+++ b/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
@@ -304,20 +304,20 @@ internal suspend fun calculateMovingAverages(
     when it comes to the averaging window. E.g. when i use the daily averaging window and track data
     at 13:01 one day, 13:00 the next day and 13:02 the day after that, the second entry gets averaged,
     but the third does not etc.
-    If one were to implement this, it would be possible to simply check whether the time-difference
+    One way to check whether the input is aggregated is to check if the time-differences
     between all consecutive datasamples are exactly the same which likely is only the case if a computer
     aggregated it.
-    The code below *tries* to implement this approach. It does *not* work and causes the app to crash,
-    but might be a starting point.
+    The code below implements this approach, but is commented out since a use for this would have to
+    be discussed first.
 
     val input_is_aggregated_total_data = when (dataPoints.size) {
-            1 -> false
+            1, 2 -> false // return false for 2, bc there is no comparison if there is only one time-difference
             else -> {
                 val inital_time_difference = Duration.between(
                         dataPoints[0].timestamp,
                         dataPoints[1].timestamp
                 )
-                (1..dataPoints.size).map( { Duration.between(
+                (1..dataPoints.size-1).map( { Duration.between(
                         dataPoints[it-1].timestamp,
                         dataPoints[it].timestamp) }).filter( { it != inital_time_difference }).size == 0
             }

--- a/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
+++ b/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
@@ -302,9 +302,9 @@ internal suspend fun calculateMovingAverages(
     Maybe sometime in the future it is desired to know here whether the input is aggregated using a
     daily+ totals aggregator, with the intent to treat data that is *not* aggregated more lenient
     when it comes to the averaging window. E.g. when i use the daily averaging window and track data
-    at 13:01 one day, 13:00 the next day and 13:02 the day after that, the second entry gets averages,
+    at 13:01 one day, 13:00 the next day and 13:02 the day after that, the second entry gets averaged,
     but the third does not etc.
-    If one where to implement this, it would be possible to simply check whether the time-difference
+    If one were to implement this, it would be possible to simply check whether the time-difference
     between all consecutive datasamples are exactly the same which likely is only the case if a computer
     aggregated it.
     The code below *tries* to implement this approach. It does *not* work and causes the app to crash,

--- a/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
+++ b/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
@@ -304,7 +304,7 @@ internal suspend fun calculateMovingAverages(
             && Duration.between(
                 dataPoints[addIndex].timestamp,
                 current.timestamp
-            ) <= movingAvDuration
+            ) < movingAvDuration
         ) {
             currentAccumulation += dataPoints[addIndex++].value
             currentCount++

--- a/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
+++ b/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
@@ -297,6 +297,33 @@ internal suspend fun calculateMovingAverages(
     var currentCount = 0
     var addIndex = 0
     val dataPoints = dataSample.dataPoints.reversed()
+
+    /*
+    Maybe sometime in the future it is desired to know here whether the input is aggregated using a
+    daily+ totals aggregator, with the intent to treat data that is *not* aggregated more lenient
+    when it comes to the averaging window. E.g. when i use the daily averaging window and track data
+    at 13:01 one day, 13:00 the next day and 13:02 the day after that, the second entry gets averages,
+    but the third does not etc.
+    If one where to implement this, it would be possible to simply check whether the time-difference
+    between all consecutive datasamples are exactly the same which likely is only the case if a computer
+    aggregated it.
+    The code below *tries* to implement this approach. It does *not* work and causes the app to crash,
+    but might be a starting point.
+
+    val input_is_aggregated_total_data = when (dataPoints.size) {
+            1 -> false
+            else -> {
+                val inital_time_difference = Duration.between(
+                        dataPoints[0].timestamp,
+                        dataPoints[1].timestamp
+                )
+                (1..dataPoints.size).map( { Duration.between(
+                        dataPoints[it-1].timestamp,
+                        dataPoints[it].timestamp) }).filter( { it != inital_time_difference }).size == 0
+            }
+    }
+    */
+
     for (index in dataPoints.indices) {
         yield()
         val current = dataPoints[index]

--- a/app/src/test/java/com/samco/trackandgraph/statistics/Statistics_calculateMovingAverages_KtTest.kt
+++ b/app/src/test/java/com/samco/trackandgraph/statistics/Statistics_calculateMovingAverages_KtTest.kt
@@ -28,6 +28,10 @@ class Statistics_calculateMovingAverages_KtTest {
 
     @Test
     fun calculateMovingAverages() {
+        /* The test assumes that datapoints will only be averages when the time between is
+           smaller than the given window, NOT smaller or equal, e.g. the last two points will not be
+           averaged together since they are exactly 10 hours apart, not less.
+         */
         runBlocking {
             //GIVEN
             val now = OffsetDateTime.now()
@@ -48,7 +52,7 @@ class Statistics_calculateMovingAverages_KtTest {
             val answer = calculateMovingAverages(DataSample(dataPoints), averagingDuration)
 
             //THEN
-            val expected = listOf(5.0, 0.0, 2.0, 2.0, 1.5, 2.0, 8.0, 7.5, 5.0)
+            val expected = listOf(5.0, 0.0, 2.0, 2.0, 1.5, 2.0, 8.0, 7.0, 3.0)
             val actual = answer.dataPoints.map { dp -> dp.value }
             assertEquals(expected, actual)
         }


### PR DESCRIPTION
Fixes issue #70 .

Okay so the fix was very easy (change <= to < ) (line 334).

After finding this fix i got the (unreasonable) urge to add some extra code so that the behavior is unchanged for non-aggregated data (plot-when-tracked). So I came up with an idea to find out whether the input data is aggregated or not, so the function can behave differently for the two cases (agg, non-agg). Long story short: the code i wrote to differentiate the inputs doesn't work (no errors, but crashes the app), so I left it as a comment for future reference (together with some explanations) in case someone wants to implement different behavior for the different cases. What that should be and if its 'good' is a different question.

I think the fix is good and the edge case where the fix would actually impact the plot-when-tracked data is very rare.

Whether the comment should be kept in the code is a different question. Maybe remove the code (since it non-working) and replace it with some pseudo code, or just remove the whole comment. I myself am not sure if i want it there.