### PR TITLE
Adaptive y-range fix: adaptive ranges now work correctly in fixed bounds mode

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
+++ b/app/src/main/java/com/samco/trackandgraph/statistics/Statistics.kt
@@ -609,7 +609,7 @@ private fun finishProtoDynamicBounds (proto: PossibleIntervalProto, y_min: Doubl
 }
 
 private fun finishProtoFixedBounds (proto: PossibleIntervalProto, y_min: Double, y_max: Double) : PossibleInterval? {
-    val y_range = y_min - y_max
+    val y_range = y_max - y_min
     // if we can't evenly divide the y_range we can't do anything, so return a bad dummy interval, which will get filtered out
     // this is a little more complex than it should be because of floating point errors
     if (y_range.div(proto.interval).rem(1) != 0.0 ) return null //PossibleInterval(0.0, false, 999, 0.0, 0.0, 0.0, 1.0)


### PR DESCRIPTION
I was wondering why the adaptive interval didn't work when using fixed bounds mode (even though I programmed it to do so). 
Turns out subtraction is not symmetric!