### PR TITLE
Fix: Resolves a bug where y-intervals would be one second

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/graphstatview/decorators/GraphStatLineGraphDecorator.kt
+++ b/app/src/main/java/com/samco/trackandgraph/graphstatview/decorators/GraphStatLineGraphDecorator.kt
@@ -47,6 +47,7 @@ import java.text.ParsePosition
 import kotlin.math.abs
 import kotlin.math.log10
 import kotlin.math.max
+import kotlin.math.roundToLong
 
 class GraphStatLineGraphDecorator(listMode: Boolean) :
     GraphStatViewDecorator<ILineGraphViewData>(listMode) {
@@ -157,7 +158,7 @@ class GraphStatLineGraphDecorator(listMode: Boolean) :
                         toAppendTo: StringBuffer,
                         pos: FieldPosition
                     ): StringBuffer {
-                        val sec = (obj as Number).toLong()
+                        val sec = (obj as Number).toDouble().roundToLong()
                         return toAppendTo.append(formatTimeDuration(sec))
                     }
 


### PR DESCRIPTION
Fixes #88 
There appears to sometimes be a floating point error which then gets amplified by being floored by the toLong call. Rounding it resolves the issue.
Before:
![pre_fix](https://user-images.githubusercontent.com/77058867/114993574-3a971a00-9e9c-11eb-94d4-14a99a983c03.png)

After:
![post_fix](https://user-images.githubusercontent.com/77058867/114993584-3bc84700-9e9c-11eb-89fe-46da13800d39.png)
