### PR TITLE
Implements #15

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/InputDataPointDialog.kt
+++ b/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/InputDataPointDialog.kt
@@ -42,6 +42,8 @@ import com.samco.trackandgraph.util.hideKeyboard
 import com.samco.trackandgraph.util.showKeyboard
 import kotlinx.android.synthetic.main.data_point_input_dialog.*
 import kotlinx.coroutines.*
+import java.util.*
+import kotlin.concurrent.timerTask
 
 const val FEATURE_LIST_KEY = "FEATURE_LIST_KEY"
 const val DATA_POINT_TIMESTAMP_KEY = "DATA_POINT_ID"
@@ -50,6 +52,7 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
     private val viewModel by viewModels<InputDataPointDialogViewModel>()
     private val inputViews = mutableMapOf<Int, DataPointInputView>()
     private lateinit var binding: DataPointInputDialogBinding
+
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -67,6 +70,12 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
             listenToFeatures()
             listenToIndex()
             listenToState()
+
+            Timer().scheduleAtFixedRate(timerTask {
+                getActivity()?.runOnUiThread {
+                    (binding.viewPager.adapter as ViewPagerAdapter).updateStopwatch()
+                }
+            }, 1000, 1000)
 
             binding.viewPager.addOnPageChangeListener(this)
             dialog?.setCanceledOnTouchOutside(true)
@@ -176,6 +185,10 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
             existingViews.forEach { dpiv -> dpiv.updateDateTimes() }
         }
 
+        fun updateStopwatch() {
+            existingViews.forEach { dpiv -> dpiv.updateStopwatchIfNeeded() }
+        }
+
         override fun getCount() = features.size
     }
 
@@ -208,6 +221,8 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
     private fun onAddClicked() {
         val currIndex = viewModel.currentFeatureIndex.value!!
         val currFeature = viewModel.features.value!![currIndex]
+        (binding.viewPager.adapter as ViewPagerAdapter).updateStopwatch()
+
         viewModel.uiStates[currFeature]?.timeFixed = true
         onAddClicked(currFeature)
     }

--- a/app/src/main/res/drawable/stopwatch.xml
+++ b/app/src/main/res/drawable/stopwatch.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:pivotX="16"
+        android:pivotY="12"
+        android:scaleX="0.75"
+        android:scaleY="1">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M15.07,1.01h-6v2h6v-2zM11.07,14.01h2v-6h-2v6zM19.1,7.39l1.42,-1.42c-0.43,-0.51 -0.9,-0.99 -1.41,-1.41l-1.42,1.42C16.14,4.74 14.19,4 12.07,4c-4.97,0 -9,4.03 -9,9s4.02,9 9,9 9,-4.03 9,-9c0,-2.11 -0.74,-4.06 -1.97,-5.61zM12.07,20.01c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z" />
+    </group>
+</vector>

--- a/app/src/main/res/layout/data_point_input_view.xml
+++ b/app/src/main/res/layout/data_point_input_view.xml
@@ -128,12 +128,32 @@
                 tools:ignore="HardcodedText"
                 tools:text="33" />
 
-            <com.samco.trackandgraph.ui.DurationInputView
-                android:id="@+id/durationInput"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/durationInputContainer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <com.samco.trackandgraph.ui.DurationInputView
+                    android:id="@+id/durationInput"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"/>
+
+                <ToggleButton
+                    android:id="@+id/stopwatchButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_marginStart="4dp"
+                    android:button="@drawable/stopwatch"
+                    app:layout_constraintBottom_toBottomOf="@id/durationInput"
+                    app:layout_constraintLeft_toRightOf="@id/durationInput"
+                    app:layout_constraintTop_toTopOf="@id/durationInput"
+                    app:layout_constraintVertical_bias="0.0" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <HorizontalScrollView
                 android:id="@+id/buttonsScrollView"


### PR DESCRIPTION
- add stopwatch icon resource with artificial padding
- add toggle button for DurationInputs
- add stopwatch logic that allows to record time-durations in the app

references #161 (i screwed up the PR by changing branches)


## Description
adds a small toggle button to time-duration recordings.

When the button is enabled it will start recording the time and update the duration input live. It will update and stay up to date.

When the button is disabled the recording is stopped and the widget can be modified to the users liking.


![image](https://user-images.githubusercontent.com/2736207/177334459-6ec0ebf1-e19d-4a52-a0cf-70872979c187.png)
