### PR TITLE
Implements #15 (third times the charm)

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/DataPointInputView.kt
+++ b/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/DataPointInputView.kt
@@ -23,6 +23,7 @@ import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 import android.view.inputmethod.EditorInfo
 import android.widget.*
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -38,11 +39,13 @@ import com.samco.trackandgraph.ui.doubleFormatter
 import com.samco.trackandgraph.ui.formatDayMonthYear
 import com.samco.trackandgraph.util.getDoubleFromText
 import com.samco.trackandgraph.util.showKeyboard
+import com.samco.trackandgraph.util.window
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZonedDateTime
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.*
+
 
 class DataPointInputView : FrameLayout {
     private val titleText: TextView
@@ -83,6 +86,10 @@ class DataPointInputView : FrameLayout {
         stopwatchButton.setOnClickListener {
             startTime = GregorianCalendar.getInstance().timeInMillis
             isStopwatched = stopwatchButton.isChecked
+            context.window?.run {
+                // https://developer.android.com/training/scheduling/wakelock
+                if (isStopwatched) addFlags(FLAG_KEEP_SCREEN_ON) else clearFlags(FLAG_KEEP_SCREEN_ON)
+            }
         }
     }
 
@@ -275,3 +282,4 @@ class DataPointInputView : FrameLayout {
         }
     }
 }
+

--- a/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/InputDataPointDialog.kt
+++ b/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/InputDataPointDialog.kt
@@ -43,6 +43,8 @@ import com.samco.trackandgraph.util.showKeyboard
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
+import java.util.*
+import kotlin.concurrent.timerTask
 import javax.inject.Inject
 
 const val FEATURE_LIST_KEY = "FEATURE_LIST_KEY"
@@ -70,6 +72,12 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
             listenToFeatures()
             listenToIndex()
             listenToState()
+
+            Timer().scheduleAtFixedRate(timerTask {
+                getActivity()?.runOnUiThread {
+                    (binding.viewPager.adapter as ViewPagerAdapter).updateStopwatch()
+                }
+            }, 1000, 1000)
 
             binding.viewPager.addOnPageChangeListener(this)
             dialog?.setCanceledOnTouchOutside(true)
@@ -181,6 +189,10 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
 
         fun updateAllDateTimes() = existingViews.forEach { dpiv -> dpiv.updateDateTimes() }
 
+        fun updateStopwatch() {
+            existingViews.forEach { dpiv -> dpiv.updateStopwatchIfNeeded() }
+        }
+
         override fun getCount() = features.size
     }
 
@@ -213,6 +225,8 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
     private fun onAddClicked() {
         val currIndex = viewModel.currentFeatureIndex.value!!
         val currFeature = viewModel.features.value!![currIndex]
+        (binding.viewPager.adapter as ViewPagerAdapter).updateStopwatch()
+
         viewModel.uiStates[currFeature]?.timeFixed = true
         onAddClicked(currFeature)
     }

--- a/app/src/main/java/com/samco/trackandgraph/util/UtilFuncs.kt
+++ b/app/src/main/java/com/samco/trackandgraph/util/UtilFuncs.kt
@@ -19,6 +19,7 @@ package com.samco.trackandgraph.util
 
 import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.os.Build
 import android.os.IBinder
 import android.os.VibrationEffect
@@ -29,6 +30,7 @@ import android.view.inputmethod.InputMethodManager
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.AppCompatActivity
+import com.samco.trackandgraph.displaytrackgroup.DataPointInputView
 import java.lang.NumberFormatException
 
 /**
@@ -74,6 +76,19 @@ fun Context.getColorFromAttr(
     theme.resolveAttribute(attrColor, typedValue, resolveRefs)
     return typedValue.data
 }
+
+val Context.window: Window?
+    // https://stackoverflow.com/a/32973351/13310191
+    get() {
+        var context_ = this
+        while (context_ is ContextWrapper) {
+            if (context_ is Activity) {
+                return context_.window
+            }
+            context_ = context_.baseContext
+        }
+        return null
+    }
 
 fun Window.hideKeyboard(windowToken: IBinder? = null, flags: Int = 0) {
     val imm = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager

--- a/app/src/main/res/drawable/stopwatch.xml
+++ b/app/src/main/res/drawable/stopwatch.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:pivotX="16"
+        android:pivotY="12"
+        android:scaleX="0.75"
+        android:scaleY="1">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M15.07,1.01h-6v2h6v-2zM11.07,14.01h2v-6h-2v6zM19.1,7.39l1.42,-1.42c-0.43,-0.51 -0.9,-0.99 -1.41,-1.41l-1.42,1.42C16.14,4.74 14.19,4 12.07,4c-4.97,0 -9,4.03 -9,9s4.02,9 9,9 9,-4.03 9,-9c0,-2.11 -0.74,-4.06 -1.97,-5.61zM12.07,20.01c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z" />
+    </group>
+</vector>

--- a/app/src/main/res/layout/data_point_input_view.xml
+++ b/app/src/main/res/layout/data_point_input_view.xml
@@ -128,12 +128,32 @@
                 tools:ignore="HardcodedText"
                 tools:text="33" />
 
-            <com.samco.trackandgraph.ui.DurationInputView
-                android:id="@+id/durationInput"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/durationInputContainer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <com.samco.trackandgraph.ui.DurationInputView
+                    android:id="@+id/durationInput"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"/>
+
+                <ToggleButton
+                    android:id="@+id/stopwatchButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_marginStart="4dp"
+                    android:button="@drawable/stopwatch"
+                    app:layout_constraintBottom_toBottomOf="@id/durationInput"
+                    app:layout_constraintLeft_toRightOf="@id/durationInput"
+                    app:layout_constraintTop_toTopOf="@id/durationInput"
+                    app:layout_constraintVertical_bias="0.0" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <HorizontalScrollView
                 android:id="@+id/buttonsScrollView"


### PR DESCRIPTION
- add stopwatch icon resource with artificial padding
- add toggle button for DurationInputs
- add stopwatch logic that allows to record time-durations in the app

references #161 (i screwed up the PR by changing branches)


## Description
adds a small toggle button to time-duration recordings.

When the button is enabled it will start recording the time and update the duration input live. It will update and stay up to date.

When the button is disabled the recording is stopped and the widget can be modified to the users liking.


![image](https://user-images.githubusercontent.com/2736207/177334459-6ec0ebf1-e19d-4a52-a0cf-70872979c187.png)
