### PR TITLE
Fix 143 keyboard remains after input data point dialog close

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/AddFeatureFragment.kt
+++ b/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/AddFeatureFragment.kt
@@ -49,7 +49,7 @@ import com.samco.trackandgraph.ui.YesCancelDialogFragment
 import com.samco.trackandgraph.util.getColorFromAttr
 import com.samco.trackandgraph.util.getDoubleFromText
 import com.samco.trackandgraph.util.hideKeyboard
-import com.samco.trackandgraph.util.showKeyboard
+import com.samco.trackandgraph.util.focusAndShowKeyboard
 import com.samco.trackandgraph.widgets.TrackWidgetProvider
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -75,8 +75,8 @@ class AddFeatureFragment : Fragment(), YesCancelDialogFragment.YesCancelDialogLi
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = AddFeatureFragmentBinding.inflate(inflater, container, false)
         navController = container?.findNavController()
+        binding = AddFeatureFragmentBinding.inflate(inflater, container, false)
 
         viewModel.init(
             args.groupId,
@@ -85,6 +85,8 @@ class AddFeatureFragment : Fragment(), YesCancelDialogFragment.YesCancelDialogLi
         )
 
         listenToViewModelState()
+
+        binding.featureNameText.focusAndShowKeyboard()
         return binding.root
     }
 
@@ -94,7 +96,6 @@ class AddFeatureFragment : Fragment(), YesCancelDialogFragment.YesCancelDialogLi
             NavButtonStyle.UP,
             getString(R.string.add_feature)
         )
-        requireContext().showKeyboard()
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/DataPointInputView.kt
+++ b/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/DataPointInputView.kt
@@ -35,8 +35,8 @@ import com.samco.trackandgraph.base.database.dto.Feature
 import com.samco.trackandgraph.ui.DurationInputView
 import com.samco.trackandgraph.ui.doubleFormatter
 import com.samco.trackandgraph.ui.formatDayMonthYear
+import com.samco.trackandgraph.util.focusAndShowKeyboard
 import com.samco.trackandgraph.util.getDoubleFromText
-import com.samco.trackandgraph.util.showKeyboard
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZonedDateTime
@@ -118,15 +118,19 @@ class DataPointInputView : FrameLayout {
         addNoteButton.setOnClickListener {
             addNoteButton.visibility = View.GONE
             noteInput.visibility = View.VISIBLE
-            context.showKeyboard()
-            noteInput.post { noteInput.requestFocus() }
+            noteInput.focusAndShowKeyboard()
         }
         noteInput.addTextChangedListener { state.note = it.toString() }
     }
 
     override fun requestFocus(direction: Int, previouslyFocusedRect: Rect?): Boolean {
-        return if (state.feature.featureType == DataType.CONTINUOUS) numberInput.requestFocus()
-        else super.requestFocus(direction, previouslyFocusedRect)
+        return if (state.feature.featureType == DataType.CONTINUOUS) {
+            numberInput.focusAndShowKeyboard()
+            val result = numberInput.requestFocus()
+            result
+        } else if (state.feature.featureType == DataType.DURATION) {
+            durationInput.requestFocus()
+        } else super.requestFocus(direction, previouslyFocusedRect)
     }
 
     private fun initDiscrete() {
@@ -140,6 +144,7 @@ class DataPointInputView : FrameLayout {
                 .first { cb -> cb.text == state.label }
                 .isChecked = true
         }
+        numberInput.focusAndShowKeyboard()
     }
 
     private fun initContinuous() {

--- a/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/InputDataPointDialog.kt
+++ b/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/InputDataPointDialog.kt
@@ -37,8 +37,6 @@ import com.samco.trackandgraph.base.model.DataInteractor
 import com.samco.trackandgraph.databinding.DataPointInputDialogBinding
 import com.samco.trackandgraph.di.IODispatcher
 import com.samco.trackandgraph.di.MainDispatcher
-import com.samco.trackandgraph.util.hideKeyboard
-import com.samco.trackandgraph.util.showKeyboard
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
@@ -48,7 +46,7 @@ const val FEATURE_LIST_KEY = "FEATURE_LIST_KEY"
 const val DATA_POINT_TIMESTAMP_KEY = "DATA_POINT_ID"
 
 @AndroidEntryPoint
-open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListener {
+open class InputDataPointDialog : DialogFragment() {
     private val viewModel by viewModels<InputDataPointDialogViewModel>()
     private val inputViews = mutableMapOf<Int, DataPointInputView>()
     private lateinit var binding: DataPointInputDialogBinding
@@ -70,7 +68,23 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
             listenToIndex()
             listenToState()
 
-            binding.viewPager.addOnPageChangeListener(this)
+            binding.viewPager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
+                override fun onPageScrolled(
+                    position: Int,
+                    positionOffset: Float,
+                    positionOffsetPixels: Int
+                ) {
+                }
+
+
+                override fun onPageSelected(position: Int) {
+                    (binding.viewPager.adapter as ViewPagerAdapter).updateAllDateTimes()
+                    viewModel.currentFeatureIndex.value = position
+                }
+
+                override fun onPageScrollStateChanged(state: Int) {
+                }
+            })
             dialog?.setCanceledOnTouchOutside(true)
 
             binding.root
@@ -168,8 +182,10 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
         override fun setPrimaryItem(container: ViewGroup, position: Int, `object`: Any) {
             super.setPrimaryItem(container, position, `object`)
             if (currentPosition != position && `object` is DataPointInputView) {
+                val view = `object`
                 currentPosition = position
-                `object`.requestFocus()
+                view.requestFocus()
+
             }
         }
 
@@ -183,22 +199,15 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
         override fun getCount() = features.size
     }
 
-    override fun onPageScrollStateChanged(state: Int) {}
-    override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
-    override fun onPageSelected(position: Int) {
-        (binding.viewPager.adapter as ViewPagerAdapter).updateAllDateTimes()
-        viewModel.currentFeatureIndex.value = position
-    }
 
     private fun setupViewFeature(feature: Feature, index: Int) {
-        if (feature.featureType != DataType.DISCRETE) binding.addButton.visibility = View.VISIBLE
-        else binding.addButton.visibility = View.INVISIBLE
         binding.indexText.text = "${index + 1} / ${viewModel.features.value!!.size}"
-
-        //SHOW/HIDE KEYBOARD
-        if (feature.featureType != DataType.DISCRETE) context?.showKeyboard()
-        else activity?.window?.hideKeyboard(view?.windowToken, 0)
-        requireActivity().currentFocus?.clearFocus()
+        if (feature.featureType != DataType.DISCRETE) {
+            binding.addButton.visibility = View.VISIBLE
+        } else {
+            binding.addButton.visibility = View.INVISIBLE
+        }
+        //requireActivity().currentFocus?.clearFocus()
     }
 
     override fun onResume() {
@@ -207,6 +216,7 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.WRAP_CONTENT
         )
+        binding.viewPager.focusedChild?.requestFocus()
     }
 
     private fun onAddClicked() {
@@ -218,12 +228,6 @@ open class InputDataPointDialog : DialogFragment(), ViewPager.OnPageChangeListen
 
     private fun onAddClicked(feature: Feature) {
         onSubmitResult(viewModel.uiStates[feature]!!)
-    }
-
-    override fun onDismiss(dialog: DialogInterface) {
-        super.onDismiss(dialog)
-        requireActivity().currentFocus?.clearFocus()
-        requireActivity().window?.hideKeyboard(flags = InputMethodManager.HIDE_NOT_ALWAYS)
     }
 
     private fun onSubmitResult(dataPointInputData: DataPointInputView.DataPointInputData) {

--- a/app/src/main/java/com/samco/trackandgraph/graphstatinput/GraphStatInputFragment.kt
+++ b/app/src/main/java/com/samco/trackandgraph/graphstatinput/GraphStatInputFragment.kt
@@ -19,6 +19,7 @@ package com.samco.trackandgraph.graphstatinput
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -46,6 +47,7 @@ import com.samco.trackandgraph.di.MainDispatcher
 import com.samco.trackandgraph.graphstatinput.configviews.*
 import com.samco.trackandgraph.graphstatproviders.GraphStatInteractorProvider
 import com.samco.trackandgraph.graphstatview.factories.viewdto.IGraphStatViewData
+import com.samco.trackandgraph.util.focusAndShowKeyboard
 import com.samco.trackandgraph.util.hideKeyboard
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -60,7 +62,7 @@ class GraphStatInputFragment : Fragment() {
     private lateinit var binding: FragmentGraphStatInputBinding
     private val viewModel by viewModels<GraphStatInputViewModel>()
 
-    private val updateDemoHandler = Handler()
+    private val updateDemoHandler = Handler(Looper.getMainLooper())
 
     private lateinit var currentConfigView: GraphStatConfigView
 
@@ -74,7 +76,7 @@ class GraphStatInputFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        this.navController = container?.findNavController()
+        navController = container?.findNavController()
         binding = FragmentGraphStatInputBinding.inflate(inflater, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         viewModel.initViewModel(args.groupId, args.graphStatId)
@@ -111,6 +113,7 @@ class GraphStatInputFragment : Fragment() {
                     listenToDemoViewData()
                     listenToAddButton()
                     listenToPreviewButton()
+                    binding.graphStatNameInput.focusAndShowKeyboard()
                 }
                 GraphStatInputState.ADDING -> binding.inputProgressBar.visibility = View.VISIBLE
                 else -> navController?.popBackStack()

--- a/app/src/main/java/com/samco/trackandgraph/group/AddGroupDialog.kt
+++ b/app/src/main/java/com/samco/trackandgraph/group/AddGroupDialog.kt
@@ -37,8 +37,8 @@ import com.samco.trackandgraph.base.database.dto.Group
 import com.samco.trackandgraph.base.model.DataInteractor
 import com.samco.trackandgraph.ui.ColorSpinnerAdapter
 import com.samco.trackandgraph.ui.dataVisColorList
+import com.samco.trackandgraph.util.focusAndShowKeyboard
 import com.samco.trackandgraph.util.getColorFromAttr
-import com.samco.trackandgraph.util.showKeyboard
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
@@ -50,7 +50,6 @@ const val ADD_GROUP_DIALOG_PARENT_ID_KEY = "ADD_GROUP_DIALOG_PARENT_ID_KEY"
 @AndroidEntryPoint
 class AddGroupDialog : DialogFragment(), TextWatcher {
     private lateinit var alertDialog: AlertDialog
-
     private lateinit var editText: EditText
     private lateinit var colorSpinner: Spinner
 
@@ -64,12 +63,8 @@ class AddGroupDialog : DialogFragment(), TextWatcher {
         val dialog = initDialog(groupId != null)
         viewModel.initViewModel(groupId, parentGroupId)
         observeViewModel()
+        editText.focusAndShowKeyboard()
         return dialog
-    }
-
-    override fun onStart() {
-        super.onStart()
-        requireContext().showKeyboard()
     }
 
     private fun observeViewModel() {

--- a/app/src/main/java/com/samco/trackandgraph/ui/DurationInputView.kt
+++ b/app/src/main/java/com/samco/trackandgraph/ui/DurationInputView.kt
@@ -18,12 +18,14 @@
 package com.samco.trackandgraph.ui
 
 import android.content.Context
+import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.inputmethod.EditorInfo
 import android.widget.FrameLayout
 import androidx.core.widget.addTextChangedListener
 import com.samco.trackandgraph.databinding.DurationInputLayoutBinding
+import com.samco.trackandgraph.util.focusAndShowKeyboard
 
 class DurationInputView : FrameLayout {
     val binding = DurationInputLayoutBinding.inflate(LayoutInflater.from(context), this, true)
@@ -49,7 +51,11 @@ class DurationInputView : FrameLayout {
             }
             return@setOnEditorActionListener false
         }
-        binding.hoursInput.requestFocus()
+        binding.hoursInput.focusAndShowKeyboard()
+    }
+
+    override fun requestFocus(direction: Int, previouslyFocusedRect: Rect?): Boolean {
+        return binding.hoursInput.requestFocus()
     }
 
     private fun onDurationTextChanged() {


### PR DESCRIPTION
I removed all the deprecated functions around keyboard showing, including the deprecated "SHOW_FORCED" enum.

I tested the code and now the keyboard even automatically shows up when you create a new graph/stat. This was not working before.

## What does this solve
Since the keyboard is never enforced it will never forcefully reappear.