### PR TITLE
Add timestamp DataType

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/AddFeatureFragment.kt
+++ b/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/AddFeatureFragment.kt
@@ -20,6 +20,7 @@ import android.app.AlertDialog
 import android.appwidget.AppWidgetManager
 import android.content.Intent
 import android.os.Bundle
+import android.provider.ContactsContract
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -67,7 +68,8 @@ class AddFeatureFragment : Fragment(), YesCancelDialogFragment.YesCancelDialogLi
     private val featureTypeList = listOf(
         DataType.DISCRETE,
         DataType.CONTINUOUS,
-        DataType.DURATION
+        DataType.DURATION,
+        DataType.TIMESTAMP
     )
 
     override fun onCreateView(
@@ -257,6 +259,11 @@ class AddFeatureFragment : Fragment(), YesCancelDialogFragment.YesCancelDialogLi
                     binding.defaultDiscreteScrollView.visibility = View.GONE
                     binding.defaultNumericalInput.visibility = View.GONE
                     binding.defaultDurationInput.visibility = View.VISIBLE
+                }
+                DataType.TIMESTAMP -> {
+                    binding.defaultDiscreteScrollView.visibility = View.GONE
+                    binding.defaultNumericalInput.visibility = View.GONE
+                    binding.defaultDurationInput.visibility = View.GONE
                 }
                 null -> {}
             }
@@ -614,6 +621,8 @@ class AddFeatureViewModel @Inject constructor(
                     || existingFeature!!.featureType == DataType.DISCRETE
                     || existingFeature!!.featureType == DataType.CONTINUOUS
             DataType.DURATION -> existingFeature!!.featureType == DataType.CONTINUOUS
+                    || existingFeature!!.featureType == DataType.DURATION
+            DataType.TIMESTAMP -> existingFeature!!.featureType == DataType.CONTINUOUS
                     || existingFeature!!.featureType == DataType.DURATION
         }
     }

--- a/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/DataPointInputView.kt
+++ b/app/src/main/java/com/samco/trackandgraph/displaytrackgroup/DataPointInputView.kt
@@ -94,7 +94,14 @@ class DataPointInputView : FrameLayout {
             DataType.CONTINUOUS -> initContinuous()
             DataType.DISCRETE -> initDiscrete()
             DataType.DURATION -> initDuration()
+            DataType.TIMESTAMP -> initTimestamp()
         }
+    }
+
+    private fun initTimestamp() {
+        buttonsScroll.visibility = View.GONE
+        numberInput.visibility = View.GONE
+        durationInput.visibility = View.GONE
     }
 
     private fun initDuration() {
@@ -218,6 +225,9 @@ class DataPointInputView : FrameLayout {
 
     private fun setSelectedDateTime(dateTime: OffsetDateTime) {
         state.dateTime = dateTime
+        if(state.feature.featureType == DataType.TIMESTAMP) {
+            state.value = dateTime.second + dateTime.minute * 60.0 + dateTime.hour * 3600.0;
+        }
         dateButton.text = formatDayMonthYear(context, dateTime)
         timeButton.text = dateTime.format(timeDisplayFormatter)
     }

--- a/app/src/main/java/com/samco/trackandgraph/graphstatinput/GraphStatInputFragment.kt
+++ b/app/src/main/java/com/samco/trackandgraph/graphstatinput/GraphStatInputFragment.kt
@@ -301,7 +301,10 @@ class GraphStatInputViewModel @Inject constructor(
                 FeatureDataProvider.FeatureData(
                     feat,
                     feat.discreteValues.map { it.label }.toSet(),
-                    DataSampleProperties(null, feat.featureType == DataType.DURATION)
+                    DataSampleProperties(
+                        null,
+                        feat.featureType == DataType.DURATION || feat.featureType == DataType.TIMESTAMP
+                    )
                 )
             }
             featureDataProvider = FeatureDataProvider(featureData, allGroups)

--- a/app/src/main/java/com/samco/trackandgraph/group/GroupViewModel.kt
+++ b/app/src/main/java/com/samco/trackandgraph/group/GroupViewModel.kt
@@ -159,13 +159,18 @@ class GroupViewModel @Inject constructor(
     }
 
     fun addDefaultFeatureValue(feature: DisplayFeature) = viewModelScope.launch(io) {
+        val ts = OffsetDateTime.now()
+        var defaultValue = feature.defaultValue
+        if (feature.featureType == DataType.TIMESTAMP) {
+            defaultValue = ts.second + ts.minute * 60.0 + ts.hour * 3600.0
+        }
         val label = if (feature.featureType == DataType.DISCRETE) {
             feature.discreteValues[feature.defaultValue.toInt()].label
         } else ""
         val newDataPoint = DataPoint(
-            OffsetDateTime.now(),
+            ts,
             feature.id,
-            feature.defaultValue,
+            defaultValue,
             label,
             ""
         )

--- a/app/src/main/java/com/samco/trackandgraph/ui/DateTimeFormatters.kt
+++ b/app/src/main/java/com/samco/trackandgraph/ui/DateTimeFormatters.kt
@@ -84,6 +84,7 @@ fun IDataPoint.getDisplayValue(dataType: DataType): String {
         DataType.DISCRETE -> doubleFormatter.format(this.value) + " : ${this.label}"
         DataType.CONTINUOUS -> doubleFormatter.format(this.value)
         DataType.DURATION -> formatTimeDuration(this.value.toLong())
+        DataType.TIMESTAMP -> formatTimestamp(this.value.toLong())
     }
 }
 
@@ -135,4 +136,9 @@ fun formatMonthYear(context: Context, temporal: Temporal): String {
 fun formatTimeDuration(seconds: Long): String {
     val absSecs = kotlin.math.abs(seconds)
     return String.format("%d:%02d:%02d", seconds / 3600, (absSecs % 3600) / 60, (absSecs % 60))
+}
+
+fun formatTimestamp(seconds: Long): String {
+    val absSecs = kotlin.math.abs(seconds)
+    return String.format("%d:%02d", seconds / 3600, (absSecs % 3600) / 60)
 }

--- a/app/src/main/java/com/samco/trackandgraph/widgets/TrackWidgetInputDataPointActivity.kt
+++ b/app/src/main/java/com/samco/trackandgraph/widgets/TrackWidgetInputDataPointActivity.kt
@@ -24,6 +24,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.samco.trackandgraph.base.database.dto.DataPoint
+import com.samco.trackandgraph.base.database.dto.DataType
 import com.samco.trackandgraph.base.database.dto.Feature
 import com.samco.trackandgraph.base.model.DataInteractor
 import com.samco.trackandgraph.displaytrackgroup.FEATURE_LIST_KEY
@@ -107,10 +108,15 @@ class TrackWidgetInputDataPointViewModel @Inject constructor(
 
     fun addDefaultDataPoint() = feature.value?.let {
         ioScope.launch {
+            val ts = OffsetDateTime.now()
+            var defaultValue = it.defaultValue
+            if (it.featureType == DataType.TIMESTAMP) {
+                defaultValue = ts.second + ts.minute * 60.0 + ts.hour * 3600.0
+            }
             val newDataPoint = DataPoint(
-                OffsetDateTime.now(),
+                ts,
                 it.id,
-                it.defaultValue,
+                defaultValue,
                 it.getDefaultLabel(),
                 ""
             )

--- a/base/src/main/java/com/samco/trackandgraph/base/database/dto/DataType.kt
+++ b/base/src/main/java/com/samco/trackandgraph/base/database/dto/DataType.kt
@@ -17,4 +17,4 @@
 
 package com.samco.trackandgraph.base.database.dto
 
-enum class DataType { DISCRETE, CONTINUOUS, DURATION }
+enum class DataType { DISCRETE, CONTINUOUS, DURATION, TIMESTAMP }

--- a/base/src/main/java/com/samco/trackandgraph/base/model/CSVReadWriterImpl.kt
+++ b/base/src/main/java/com/samco/trackandgraph/base/model/CSVReadWriterImpl.kt
@@ -470,8 +470,10 @@ internal class CSVReadWriterImpl @Inject constructor(
 
     private fun getFeatureTypeForValue(value: String): DataType {
         val durationRegex = Regex("\\d*:\\d{2}:\\d{2}")
+        val timestampRegex = Regex("\\d\\d?:\\d{2}")
         return when {
             value.matches(durationRegex) -> DataType.DURATION
+            value.matches(timestampRegex) -> DataType.TIMESTAMP
             value.contains(":") -> DataType.DISCRETE
             else -> DataType.CONTINUOUS
         }

--- a/base/src/main/res/values-de-rDE/strings.xml
+++ b/base/src/main/res/values-de-rDE/strings.xml
@@ -91,6 +91,7 @@
         <item>Multiple-Choice</item>
         <item>Numerisch</item>
         <item>Dauer</item>
+        <item>Zeit</item>
     </string-array>
     <string-array name="graph_types">
         <item>Liniendiagramm</item>

--- a/base/src/main/res/values-es/strings.xml
+++ b/base/src/main/res/values-es/strings.xml
@@ -91,6 +91,7 @@
         <item>Selección múltiple</item>
         <item>Numérico</item>
         <item>Duración del tiempo</item>
+        <item>Marca de tiempo</item>
     </string-array>
     <string-array name="graph_types">
         <item>Gráfico de líneas</item>

--- a/base/src/main/res/values-fr/strings.xml
+++ b/base/src/main/res/values-fr/strings.xml
@@ -91,6 +91,7 @@
         <item>Choix multiple</item>
         <item>Numérique</item>
         <item>Durée</item>
+        <item>Horodatage</item>
     </string-array>
     <string-array name="graph_types">
         <item>Graphique linéraire</item>

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
         <item>Multiple choice</item>
         <item>Numerical</item>
         <item>Time duration</item>
+        <item>Timestamp</item>
     </string-array>
     <string-array name="graph_types">
         <item>Line Graph</item>


### PR DESCRIPTION
This adds a timestamp datatype that can be used for tracking just timestamps, i.e. to track when you go to sleep or eat. This would fix #104 and #134.

This type saves the time part of the datapoint as seconds from 0:00 in the data point, similar to the duration type.

Some TODOs:
- Feature conversion to other types
- Test CSV
- The 'Your default will be...' text on the feature edit page does not completely fit. Checking the box will just use the current time as the default, unchecking the box opens the input dialog.

I'm new to this codebase / Kotlin / Android development so I wonder whether the approach I took has a chance to get merged :slightly_smiling_face:.

