### PR TITLE
Add setting to display days since (instead of the date of) last tracker update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ android {
 
     defaultConfig {
         applicationId "com.samco.trackandgraph"
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 32
         versionCode 200302
         versionName "2.3.2"

--- a/app/src/main/java/com/samco/trackandgraph/MainActivity.kt
+++ b/app/src/main/java/com/samco/trackandgraph/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.widget.AppCompatCheckBox
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.GravityCompat
@@ -39,6 +40,7 @@ import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupWithNavController
+import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager.widget.ViewPager
 import com.google.android.material.navigation.NavigationView
 import com.samco.trackandgraph.base.helpers.*
@@ -80,6 +82,7 @@ class MainActivity : AppCompatActivity() {
         initializeAppBar()
         onDrawerHideKeyboard()
         initDrawerSpinners()
+        initDisplayDaysAgoCheckBox()
         viewModel.syncAlarms()
         if (isFirstRun()) showTutorial()
         else destroyTutorial()
@@ -183,6 +186,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun onDateFormatSelected(index: Int) {
         getPrefs(applicationContext).edit().putInt(DATE_FORMAT_SETTING_PREF_KEY, index).apply()
+        refreshTrackersView()
     }
 
     private fun getDateFormatValue() = getPrefs(applicationContext).getInt(
@@ -240,6 +244,20 @@ class MainActivity : AppCompatActivity() {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q)
             resources.getStringArray(R.array.theme_names_Q)
         else resources.getStringArray(R.array.theme_names_pre_Q)
+
+    private fun initDisplayDaysAgoCheckBox() {
+        val checkbox = navView.menu.findItem(R.id.displayDaysAgoCheckBox).actionView as AppCompatCheckBox
+        checkbox.isChecked = getPrefs(applicationContext).getBoolean(DISPLAY_DAYS_AGO_SETTING_PREF_KEY, false)
+        checkbox.setOnCheckedChangeListener { _ , isChecked ->
+            getPrefs(applicationContext).edit().putBoolean(DISPLAY_DAYS_AGO_SETTING_PREF_KEY, isChecked).apply()
+            refreshTrackersView()
+        }
+    }
+
+    private fun refreshTrackersView() {
+        val itemList = findViewById<RecyclerView>(R.id.item_list)
+        itemList.adapter?.notifyDataSetChanged()
+    }
 
     private fun onDrawerHideKeyboard() {
         drawerLayout.addDrawerListener(object : DrawerLayout.DrawerListener {

--- a/app/src/main/java/com/samco/trackandgraph/group/TrackerViewHolder.kt
+++ b/app/src/main/java/com/samco/trackandgraph/group/TrackerViewHolder.kt
@@ -18,6 +18,7 @@
 package com.samco.trackandgraph.group
 
 import android.graphics.drawable.RippleDrawable
+import android.icu.text.MessageFormat
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -26,11 +27,15 @@ import android.widget.PopupMenu
 import com.samco.trackandgraph.R
 import com.samco.trackandgraph.base.database.dto.DataType
 import com.samco.trackandgraph.base.database.dto.DisplayTracker
+import com.samco.trackandgraph.base.helpers.DISPLAY_DAYS_AGO_SETTING_PREF_KEY
 import com.samco.trackandgraph.base.helpers.formatDayMonthYearHourMinute
 import com.samco.trackandgraph.base.helpers.formatTimeDuration
+import com.samco.trackandgraph.base.helpers.getPrefs
 import com.samco.trackandgraph.databinding.ListItemTrackerBinding
 import org.threeten.bp.Duration
 import org.threeten.bp.Instant
+import org.threeten.bp.OffsetDateTime
+import org.threeten.bp.temporal.ChronoUnit
 
 class TrackerViewHolder private constructor(
     private val binding: ListItemTrackerBinding,
@@ -105,8 +110,14 @@ class TrackerViewHolder private constructor(
 
     private fun setLastDateText() {
         val timestamp = tracker?.timestamp
+        val displayDaysAgo = getPrefs(binding.lastDateText.context).getBoolean(DISPLAY_DAYS_AGO_SETTING_PREF_KEY, false)
         binding.lastDateText.text = if (timestamp == null) {
             binding.lastDateText.context.getString(R.string.no_data)
+        } else if (displayDaysAgo) {
+            val message = binding.lastDateText.context.getString(R.string.days_ago)
+            val midnight = OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS).plusDays(1)
+            val daysSinceLastUpdate = Duration.between(timestamp, midnight).toDays()
+            MessageFormat.format(message, daysSinceLastUpdate)
         } else {
             formatDayMonthYearHourMinute(binding.lastDateText.context, timestamp)
         }

--- a/app/src/main/res/menu/navigation_menu.xml
+++ b/app/src/main/res/menu/navigation_menu.xml
@@ -59,6 +59,11 @@
             android:id="@+id/dateFormatSpinner"
             android:title="@string/date_format_colon"
             app:actionLayout="@layout/navigation_menu_spinner" />
+        <item
+            android:id="@+id/displayDaysAgoCheckBox"
+            android:title="@string/display_days_ago_colon"
+            app:actionViewClass="androidx.appcompat.widget.AppCompatCheckBox"
+            />
     </group>
 
 </menu>

--- a/base/src/main/java/com/samco/trackandgraph/base/helpers/PrefHelper.kt
+++ b/base/src/main/java/com/samco/trackandgraph/base/helpers/PrefHelper.kt
@@ -23,6 +23,7 @@ import androidx.appcompat.app.AppCompatActivity
 
 const val THEME_SETTING_PREF_KEY = "theme_setting"
 const val DATE_FORMAT_SETTING_PREF_KEY = "date_format_setting"
+const val DISPLAY_DAYS_AGO_SETTING_PREF_KEY = "display_days_ago_setting"
 const val FIRST_RUN_PREF_KEY = "firstrun2"
 
 fun getPrefs(context: Context, mode: Int = AppCompatActivity.MODE_PRIVATE): SharedPreferences {

--- a/base/src/main/res/values-de-rDE/strings.xml
+++ b/base/src/main/res/values-de-rDE/strings.xml
@@ -335,4 +335,6 @@
     <string name="save_changes">Änderungen speichern</string>
     <string name="timer_notification_channel_name">Timer</string>
     <string name="stop">Halt</string>
+    <string name="display_days_ago_colon">Vor Tagen anzeigen:</string>
+    <string name="days_ago">{0, plural, =0{Heute}=1{Gestern}other{Vor # Tagen}}</string>
 </resources>

--- a/base/src/main/res/values-es/strings.xml
+++ b/base/src/main/res/values-es/strings.xml
@@ -335,4 +335,6 @@
     <string name="filter_by_value">filtrar por valor</string>
     <string name="timer_notification_channel_name">Temporizadores</string>
     <string name="stop">Deténgase</string>
+    <string name="display_days_ago_colon">Mostrar hace días:</string>
+    <string name="days_ago">{0, plural, =0{Hoy}=1{Ayer}other{Hace # días}}</string>
 </resources>

--- a/base/src/main/res/values-fr/strings.xml
+++ b/base/src/main/res/values-fr/strings.xml
@@ -336,4 +336,6 @@
     <string name="save_changes">Sauvegarder les modifications</string>
     <string name="timer_notification_channel_name">Minuteries</string>
     <string name="stop">Arrêt</string>
+    <string name="display_days_ago_colon">Afficher il y a jours:</string>
+    <string name="days_ago">{0, plural, =0{Aujourd\'hui}=1{Hier}other{Il y a # jours}}</string>
 </resources>

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -295,6 +295,7 @@
     <string name="delete_reminder_content_description">Delete Reminder</string>
     <string name="theme_colon">Theme:</string>
     <string name="date_format_colon">Date format:</string>
+    <string name="display_days_ago_colon">Display days ago:</string>
     <string name="add_data_point_button_content_description">Add a data point button</string>
     <string name="tracked_data_menu_button_content_description">Tracked data menu button</string>
     <string name="tracked_data_history_button_content_description">Tracked data history button</string>
@@ -353,4 +354,5 @@
     <string name="name_your_function">Name your function: </string>
     <string name="write_your_function_here"># Write your function here</string>
     <string name="add_some_data_sources">Add some data sources</string>
+    <string name="days_ago">{0, plural, =0{Today}=1{Yesterday}other{# days ago}}</string>
 </resources>


### PR DESCRIPTION
A new checkbox will be visible in the app drawer allowing the user to display days since the last tracker update.