### PR TITLE
Related to Issue #245 - Replace tracker 'last record date' with 'elapsed time since last record'

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/group/GroupAdapter.kt
+++ b/app/src/main/java/com/samco/trackandgraph/group/GroupAdapter.kt
@@ -163,5 +163,14 @@ private class ListDiffCallback(
 abstract class GroupChildViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     abstract fun elevateCard()
     abstract fun dropCard()
+
+    /**
+     * @brief Called each seconds, usually to refresh precise timers
+     */
     open fun update() {}
+
+    /**
+     * @brief Called when the application is resumed, usually to refresh loose timers
+     */
+    open fun onResume() {}
 }

--- a/app/src/main/java/com/samco/trackandgraph/group/GroupFragment.kt
+++ b/app/src/main/java/com/samco/trackandgraph/group/GroupFragment.kt
@@ -208,6 +208,15 @@ class GroupFragment : Fragment(),
         val activity = (requireActivity() as MainActivity)
         args.groupName?.let { activity.setActionBarConfig(NavButtonStyle.UP, it) }
             ?: run { activity.setActionBarConfig(NavButtonStyle.MENU) }
+
+        /**
+         * Call onResume() to all children.
+         * Some children contains sentences like "X time ago", and need to be updated when the app is resumed.
+         * However, the precision is at the minute level, and calling update() each second seems overkill.
+         */
+        for (i in 0..(binding.itemList.adapter?.itemCount ?: 0)) {
+            (binding.itemList.findViewHolderForAdapterPosition(i) as GroupChildViewHolder?)?.onResume()
+        }
     }
 
     private fun createGroupClickListener() = GroupClickListener(

--- a/app/src/main/java/com/samco/trackandgraph/group/TrackerViewHolder.kt
+++ b/app/src/main/java/com/samco/trackandgraph/group/TrackerViewHolder.kt
@@ -23,7 +23,7 @@ import android.widget.PopupMenu
 import com.samco.trackandgraph.R
 import com.samco.trackandgraph.base.database.dto.DataType
 import com.samco.trackandgraph.base.database.dto.DisplayTracker
-import com.samco.trackandgraph.base.helpers.formatDayMonthYearHourMinute
+import com.samco.trackandgraph.base.helpers.formatRelativeTimeSpan
 import com.samco.trackandgraph.base.helpers.formatTimeDuration
 import com.samco.trackandgraph.databinding.ListItemTrackerBinding
 import org.threeten.bp.Duration
@@ -75,6 +75,11 @@ class TrackerViewHolder private constructor(
     override fun update() {
         super.update()
         updateTimerText()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setLastDateText()
     }
 
     private fun updateTimerText() {
@@ -129,7 +134,7 @@ class TrackerViewHolder private constructor(
         binding.lastDateText.text = if (timestamp == null) {
             binding.lastDateText.context.getString(R.string.no_data)
         } else {
-            formatDayMonthYearHourMinute(binding.lastDateText.context, timestamp)
+            formatRelativeTimeSpan(timestamp)
         }
     }
 

--- a/app/src/main/res/layout/list_item_tracker.xml
+++ b/app/src/main/res/layout/list_item_tracker.xml
@@ -60,34 +60,18 @@
 
                 <TextView
                     android:id="@+id/lastDateText"
-                    android:layout_width="0dp"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="5dp"
                     android:layout_marginEnd="@dimen/card_margin_small"
-                    android:gravity="start|center"
+                    android:gravity="center|center"
                     android:paddingVertical="8dp"
                     android:textAppearance="@style/TextAppearance.Body"
                     app:layout_constraintBottom_toTopOf="@id/divider"
-                    app:layout_constraintLeft_toRightOf="@id/historyIcon"
+                    app:layout_constraintLeft_toRightOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/trackGroupNameText"
-                    tools:text="02/03/19  20:18" />
-
-                <ImageView
-                    android:id="@+id/historyIcon"
-                    android:layout_width="28dp"
-                    android:layout_height="0dp"
-                    android:layout_marginStart="@dimen/card_margin_small"
-                    android:alpha="0.55"
-                    android:background="@null"
-                    android:contentDescription="@string/tracked_data_history_button_content_description"
-                    android:scaleType="fitCenter"
-                    app:layout_constraintBottom_toBottomOf="@id/lastDateText"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toLeftOf="@id/lastDateText"
-                    app:layout_constraintTop_toTopOf="@id/lastDateText"
-                    app:srcCompat="@drawable/history"
-                    app:tint="?attr/colorControlNormal" />
+                    tools:text="123 days ago" />
 
                 <View
                     android:id="@+id/divider"

--- a/base/src/main/java/com/samco/trackandgraph/base/helpers/DateTimeFormatters.kt
+++ b/base/src/main/java/com/samco/trackandgraph/base/helpers/DateTimeFormatters.kt
@@ -18,6 +18,7 @@
 package com.samco.trackandgraph.base.helpers
 
 import android.content.Context
+import android.text.format.DateUtils
 import com.samco.trackandgraph.base.R
 import com.samco.trackandgraph.base.database.dto.IDataPoint
 import com.samco.trackandgraph.base.database.dto.DataPoint
@@ -217,3 +218,8 @@ fun formatTimeToDaysHoursMinutesSeconds(
     }.toString()
 }
 
+fun formatRelativeTimeSpan(
+    dateTime: OffsetDateTime
+): String {
+    return DateUtils.getRelativeTimeSpanString(dateTime.toInstant().toEpochMilli()).toString()
+}


### PR DESCRIPTION
This PR partially implement Issue #245 

Changes:
1. Tracker last record date icon removed
2. Tracker last record date centered
3. Displayed text is now 'elapsed time since last record'
4. Add onResume callback to GroupChildViewHolder

Reasons:
1. Not informative
2. More consistent with title
3. More readable
4. Needed to update time when the application is resumed