### PR TITLE
Related to Issue #245 - Move number of records from main page to feature history

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/MainActivity.kt
+++ b/app/src/main/java/com/samco/trackandgraph/MainActivity.kt
@@ -132,21 +132,32 @@ class MainActivity : AppCompatActivity() {
 
     private data class NavBarConfig(
         val buttonStyle: NavButtonStyle,
-        val title: String? = null
+        val title: String? = null,
+        val clearSubtitle: Boolean = false
     )
+
+    fun setActionBarSubtitle(subtitle: String? = null) {
+        supportActionBar?.subtitle = subtitle
+    }
 
     /**
      * Set the title in the action bar and whether to show the menu button or the back button
      * in the top left. Every fragment should call this.
      */
-    fun setActionBarConfig(buttonStyle: NavButtonStyle, title: String? = null) {
-        setActionBarConfig(NavBarConfig(buttonStyle, title))
+    fun setActionBarConfig(buttonStyle: NavButtonStyle, title: String? = null, clearSubtitle: Boolean = false) {
+        setActionBarConfig(NavBarConfig(buttonStyle, title, clearSubtitle))
     }
 
     private fun setActionBarConfig(config: NavBarConfig) {
         currentNavBarConfig = config
         val title = config.title ?: getString(R.string.app_name)
         supportActionBar?.title = title
+
+        if (!config.clearSubtitle)
+        {
+            supportActionBar?.subtitle = null
+        }
+
         when (config.buttonStyle) {
             NavButtonStyle.MENU -> {
                 actionBarDrawerToggle.isDrawerIndicatorEnabled = true

--- a/app/src/main/java/com/samco/trackandgraph/featurehistory/FragmentFeatureHistory.kt
+++ b/app/src/main/java/com/samco/trackandgraph/featurehistory/FragmentFeatureHistory.kt
@@ -50,6 +50,7 @@ class FragmentFeatureHistory : Fragment() {
     ): View {
         viewModel.initViewModel(args.featureId)
         viewModel.tracker.map { it != null }.observe(viewLifecycleOwner) { initMenuProvider(it) }
+        viewModel.dataPoints.map { it.size }.observe(viewLifecycleOwner) { updateDataPointsCount(it) }
 
         return ComposeView(requireContext()).apply {
             setContent {
@@ -72,6 +73,16 @@ class FragmentFeatureHistory : Fragment() {
         }
     }
 
+    private fun updateDataPointsCount(numDataPoints: Int) {
+        val text = if (numDataPoints > 0) {
+            context?.getString(R.string.data_points, numDataPoints)
+        } else {
+            null
+        }
+
+        (requireActivity() as MainActivity).setActionBarSubtitle(text)
+    }
+
     private inner class FeatureHistoryMenuProvider(
         private val isTracker: Boolean
     ) : MenuProvider {
@@ -92,7 +103,7 @@ class FragmentFeatureHistory : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        (requireActivity() as MainActivity).setActionBarConfig(NavButtonStyle.UP, args.featureName)
+        (requireActivity() as MainActivity).setActionBarConfig(NavButtonStyle.UP, args.featureName, true)
     }
 }
 

--- a/app/src/main/java/com/samco/trackandgraph/group/TrackerViewHolder.kt
+++ b/app/src/main/java/com/samco/trackandgraph/group/TrackerViewHolder.kt
@@ -41,7 +41,6 @@ class TrackerViewHolder private constructor(
         this.clickListener = clickListener
         this.dropElevation = binding.cardView.cardElevation
         setLastDateText()
-        setNumEntriesText()
         binding.trackGroupNameText.text = tracker.name
         binding.menuButton.setOnClickListener { createContextMenu(binding.menuButton) }
         initClickEvents(tracker, clickListener)
@@ -130,15 +129,6 @@ class TrackerViewHolder private constructor(
             binding.lastDateText.context.getString(R.string.no_data)
         } else {
             formatDayMonthYearHourMinute(binding.lastDateText.context, timestamp)
-        }
-    }
-
-    private fun setNumEntriesText() {
-        val numDataPoints = tracker?.numDataPoints
-        binding.numEntriesText.text = if (numDataPoints != null) {
-            binding.numEntriesText.context.getString(R.string.data_points, numDataPoints)
-        } else {
-            binding.numEntriesText.context.getString(R.string.no_data)
         }
     }
 

--- a/app/src/main/res/layout/list_item_tracker.xml
+++ b/app/src/main/res/layout/list_item_tracker.xml
@@ -101,21 +101,6 @@
                     app:layout_constraintTop_toBottomOf="@id/lastDateText"
                     tools:ignore="ContentDescription" />
 
-                <TextView
-                    android:id="@+id/numEntriesText"
-                    android:layout_width="0dp"
-                    android:layout_height="35dp"
-                    android:layout_marginStart="@dimen/card_margin_small"
-                    android:gravity="bottom|start"
-                    android:maxLines="1"
-                    android:ellipsize="end"
-                    android:textAppearance="@style/TextAppearance.Body"
-                    app:layout_constraintBottom_toBottomOf="@id/addButtons"
-                    app:layout_constraintEnd_toStartOf="@id/playStopButtons"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/divider"
-                    tools:text="1345 Tracked" />
-
                 <FrameLayout
                     android:id="@+id/addButtons"
                     android:layout_width="45dp"
@@ -149,16 +134,16 @@
 
                 <FrameLayout
                     android:id="@+id/playStopButtons"
-                    android:layout_width="45dp"
+                    android:layout_width="match_parent"
                     android:layout_height="45dp"
-                    app:layout_constraintEnd_toStartOf="@id/addButtons"
+                    app:layout_constraintEnd_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="@id/addButtons">
 
                     <ImageButton
                         android:id="@+id/playTimerButton"
-                        android:layout_width="match_parent"
+                        android:layout_width="45dp"
                         android:layout_height="match_parent"
-                        android:layout_gravity="bottom|end"
+                        android:layout_gravity="bottom|center"
                         android:background="@null"
                         android:contentDescription="@string/add_data_point_button_content_description"
                         android:scaleType="fitXY"
@@ -167,9 +152,9 @@
 
                     <ImageButton
                         android:id="@+id/stopTimerButton"
-                        android:layout_width="match_parent"
+                        android:layout_width="45dp"
                         android:layout_height="match_parent"
-                        android:layout_gravity="bottom|end"
+                        android:layout_gravity="bottom|center"
                         android:background="@null"
                         android:contentDescription="@string/add_data_point_button_content_description"
                         android:scaleType="fitXY"


### PR DESCRIPTION
This PR partially implement Issue #245 

Changes:
1. Remove number of records from tracker card
2. Add number of records in toolbar subtitle in feature history
3. Center play/stop button in tracker card

Reason:
1. Information not usefull when adding new records
2. Number of records should still be visible somewhere
3. Less chance to miss-click + there is now room for it

<img src="https://github.com/SamAmco/track-and-graph/assets/118541570/001c2581-2af0-4bd1-a078-3d94fb868566" height="400" alt="Screenshot_20231115_153039_Debug Track   Graph">
<img src="https://github.com/SamAmco/track-and-graph/assets/118541570/4c62a1e9-46f5-4004-baa7-102cdce31ef9" height="400" alt="Screenshot_20231115_153026_Debug Track   Graph">