### PR TITLE
Related to Issue #245 - Reduce icon size in tracker list

### DIFF
--- a/app/src/main/res/layout/list_item_tracker.xml
+++ b/app/src/main/res/layout/list_item_tracker.xml
@@ -132,7 +132,7 @@
                         android:background="@null"
                         android:contentDescription="@string/add_data_point_button_content_description"
                         android:scaleType="fitXY"
-                        app:srcCompat="@drawable/add_box"
+                        app:srcCompat="@drawable/ic_add_record"
                         app:tint="?attr/colorControlNormal" />
 
                     <ImageView
@@ -143,7 +143,7 @@
                         android:background="@null"
                         android:contentDescription="@string/add_data_point_button_content_description"
                         android:scaleType="fitXY"
-                        app:srcCompat="@drawable/add_box"
+                        app:srcCompat="@drawable/ic_add_record"
                         app:tint="?attr/colorSecondary" />
                 </FrameLayout>
 

--- a/base/src/main/res/drawable/add_box.xml
+++ b/base/src/main/res/drawable/add_box.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM19,19L5,19L5,5h14v14zM11,17h2v-4h4v-2h-4L13,7h-2v4L7,11v2h4z"/>
-</vector>

--- a/base/src/main/res/drawable/ic_add_record.xml
+++ b/base/src/main/res/drawable/ic_add_record.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="m11,17h2v-4h4v-2h-4V7h-2V11H7v2h4z"/>
+</vector>

--- a/base/src/main/res/drawable/ic_play_timer.xml
+++ b/base/src/main/res/drawable/ic_play_timer.xml
@@ -1,10 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="48dp"
     android:height="48dp"
-    android:viewportWidth="48"
-    android:viewportHeight="48"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
     android:tint="?attr/colorControlNormal">
   <path
       android:fillColor="@android:color/white"
-      android:pathData="M18.35,37.2Q17.3,37.85 16.3,37.275Q15.3,36.7 15.3,35.5V12.2Q15.3,11 16.3,10.425Q17.3,9.85 18.35,10.5L36.7,22.2Q37.65,22.8 37.65,23.875Q37.65,24.95 36.7,25.5Z"/>
+      android:pathData="m9.034,16.874q-0.383,0.237 -0.748,0.027 -0.365,-0.21 -0.365,-0.648V7.747q0,-0.438 0.365,-0.648 0.365,-0.21 0.748,0.027l6.7,4.272q0.347,0.219 0.347,0.612 0,0.392 -0.347,0.593z"/>
 </vector>

--- a/base/src/main/res/drawable/ic_stop_timer.xml
+++ b/base/src/main/res/drawable/ic_stop_timer.xml
@@ -1,10 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="48dp"
     android:height="48dp"
-    android:viewportWidth="48"
-    android:viewportHeight="48"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
     android:tint="?attr/colorControlNormal">
   <path
       android:fillColor="@android:color/white"
-      android:pathData="M15.25,36.7Q13.6,36.7 12.45,35.55Q11.3,34.4 11.3,32.75V15.25Q11.3,13.6 12.45,12.425Q13.6,11.25 15.25,11.25H32.75Q34.4,11.25 35.575,12.425Q36.75,13.6 36.75,15.25V32.75Q36.75,34.4 35.575,35.55Q34.4,36.7 32.75,36.7Z"/>
+      android:pathData="M8.035,7L15.965,7A1.035,1.035 0,0 1,17 8.035L17,15.965A1.035,1.035 0,0 1,15.965 17L8.035,17A1.035,1.035 0,0 1,7 15.965L7,8.035A1.035,1.035 0,0 1,8.035 7z"/>
 </vector>

--- a/base/src/main/res/layout/track_widget.xml
+++ b/base/src/main/res/layout/track_widget.xml
@@ -66,7 +66,7 @@
             android:layout_alignParentBottom="true"
             android:layout_marginEnd="@dimen/card_margin_small"
             android:layout_marginBottom="@dimen/card_margin_small"
-            android:src="@drawable/add_box"
+            android:src="@drawable/ic_add_record"
             android:tint="?attr/colorControlNormal" />
 
         <ImageView
@@ -77,7 +77,7 @@
             android:layout_alignParentBottom="true"
             android:layout_marginEnd="@dimen/card_margin_small"
             android:layout_marginBottom="@dimen/card_margin_small"
-            android:src="@drawable/add_box"
+            android:src="@drawable/ic_add_record"
             android:tint="?attr/colorSecondary" />
 
         <ImageView


### PR DESCRIPTION
This PR partially implement Issue #245  

Changes:
1. Reduce tracker icons size

Reasons:
1. Plus icon was drag too much attention in tracker list. Tracker name needs to remain the most visible element

<img src="https://github.com/SamAmco/track-and-graph/assets/118541570/b426893b-1c39-464a-83d6-aede3e9c8f4e" alt="Widget" height="400"/>
<img src="https://github.com/SamAmco/track-and-graph/assets/118541570/f38e24eb-a343-4067-ac37-c6da138184e6" alt="Home page" height="400"/>
