### PR TITLE
Related to Issue #245 - Move timer over lastDateText when pressing record button

### DIFF
--- a/app/src/main/java/com/samco/trackandgraph/group/TrackerViewHolder.kt
+++ b/app/src/main/java/com/samco/trackandgraph/group/TrackerViewHolder.kt
@@ -63,6 +63,12 @@ class TrackerViewHolder private constructor(
         binding.stopTimerButton.visibility =
             if (tracker.timerStartInstant == null) View.GONE else View.VISIBLE
 
+        binding.lastDateText.visibility =
+            if (tracker.timerStartInstant == null) View.VISIBLE else View.INVISIBLE
+
+        binding.historyIcon.visibility =
+            if (tracker.timerStartInstant == null) View.VISIBLE else View.INVISIBLE
+
         if (tracker.timerStartInstant != null) {
             updateTimerText()
             binding.timerText.visibility = View.VISIBLE

--- a/app/src/main/res/layout/list_item_tracker.xml
+++ b/app/src/main/res/layout/list_item_tracker.xml
@@ -182,14 +182,15 @@
                     android:id="@+id/timerText"
                     android:layout_width="0dp"
                     android:layout_height="35dp"
-                    android:gravity="center|bottom"
+                    android:gravity="center|center"
                     android:lines="1"
                     android:text="0:00:00"
+                    android:textColor="?colorError"
                     android:textAppearance="@style/TextAppearance.Headline6"
-                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintBottom_toTopOf="@id/divider"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/addButtons"
+                    app:layout_constraintTop_toBottomOf="@id/trackGroupNameText"
                     tools:ignore="HardcodedText"
                     tools:text="00:00:00" />
 


### PR DESCRIPTION
This PR partially implement Issue #245 

Changes:
1. Make timer red like the stop button
2. Move timer over lastDateText when pressing record button

Reasons:
1. More consistent
2. Keep card height constant lastDateText is not needed as information when recording

<img src="https://github.com/SamAmco/track-and-graph/assets/118541570/9e1e6243-e257-4370-87ee-53cafaea02d4" alt="front page" height="400" />
